### PR TITLE
if user sped up, don't throw error

### DIFF
--- a/src/components/AuctionItem.jsx
+++ b/src/components/AuctionItem.jsx
@@ -341,14 +341,14 @@ const AuctionItem = ({ content }) => {
       weiAmount
     )
     setApprovalModalOpen(true)
-    waitForTransaction(approveTx)
+    await waitForTransaction(approveTx)
     setApprovalModalOpen(false)
     setBidInProgress(true)
     const bidTx = await contracts.MarketContract.bid(
       parseInt(itemNumber),
       weiAmount
     )
-    waitForTransaction(bidTx)
+    await waitForTransaction(bidTx)
     setBidInProgress(false)
   }
 

--- a/src/components/UserAllowance.jsx
+++ b/src/components/UserAllowance.jsx
@@ -1,13 +1,18 @@
 import { Button, CircularProgress, Grid, TextField } from '@mui/material'
 import React, { useContext, useEffect, useState } from 'react'
-import { store } from 'store/store';
+import { store } from 'store/store'
 import { useGetZoomAllowanceQuery } from '../hooks/useProfile'
 import { ethers } from 'ethers'
 import { useQueryClient } from 'react-query'
-import { marketContractAddress, maxZOOMAllowance, QUERY_KEYS } from '../constants'
+import {
+  marketContractAddress,
+  maxZOOMAllowance,
+  QUERY_KEYS,
+} from '../constants'
 import Slider from '@mui/material/Slider'
 import { styled as muiStyled } from '@mui/material/styles'
 import { compareAsBigNumbers } from '../utils/BigNumbers'
+import { waitForTransaction } from 'utils/transactions'
 
 const UserAllowanceWrapper = muiStyled('div')(({ theme }) => ({
   display: 'flex',
@@ -31,7 +36,6 @@ const UserAllowanceWrapper = muiStyled('div')(({ theme }) => ({
   '.button-wrapper': {
     marginTop: '16px',
   },
-
 }))
 
 const UserAllowance = ({ initial }) => {
@@ -51,7 +55,9 @@ const UserAllowance = ({ initial }) => {
     if (initial !== undefined) {
       setZoomAllowance(parseInt(ethers.utils.formatEther(initial.toString())))
     } else if (currentAllowance !== undefined) {
-      setZoomAllowance(parseInt(ethers.utils.formatEther(currentAllowance.toString())))
+      setZoomAllowance(
+        parseInt(ethers.utils.formatEther(currentAllowance.toString()))
+      )
     }
   }, [initial, currentAllowance])
 
@@ -60,15 +66,15 @@ const UserAllowance = ({ initial }) => {
   }
 
   const handleInputChange = (event) => {
-    setZoomAllowance(
-      event.target.value === '' ? 0 : Number(event.target.value)
-    )
+    setZoomAllowance(event.target.value === '' ? 0 : Number(event.target.value))
   }
 
   const handleBlur = () => {
     if (zoomAllowance < 0) {
       setZoomAllowance(0)
-    } else if (compareAsBigNumbers(zoomAllowance, parseInt(zoomBalance)) === 1) {
+    } else if (
+      compareAsBigNumbers(zoomAllowance, parseInt(zoomBalance)) === 1
+    ) {
       setZoomAllowance(zoomBalance)
     }
   }
@@ -78,18 +84,26 @@ const UserAllowance = ({ initial }) => {
   const onSetZoomAllowance = async () => {
     try {
       setIsSettingAllowance(true)
-      if (ethers.utils.parseEther(zoomAllowance.toString()).lt(currentAllowance)) {
+      if (
+        ethers.utils.parseEther(zoomAllowance.toString()).lt(currentAllowance)
+      ) {
         const tx = await contracts.ZoomContract.decreaseAllowance(
           marketContractAddress,
-          currentAllowance.sub(ethers.utils.parseEther(zoomAllowance.toString()))
+          currentAllowance.sub(
+            ethers.utils.parseEther(zoomAllowance.toString())
+          )
         )
-        await tx.wait()
-      } else if (ethers.utils.parseEther(zoomAllowance.toString()).gt(currentAllowance)) {
+        await waitForTransaction(tx)
+      } else if (
+        ethers.utils.parseEther(zoomAllowance.toString()).gt(currentAllowance)
+      ) {
         const tx = await contracts.ZoomContract.increaseAllowance(
           marketContractAddress,
-          ethers.utils.parseEther(zoomAllowance.toString()).sub(currentAllowance)
+          ethers.utils
+            .parseEther(zoomAllowance.toString())
+            .sub(currentAllowance)
         )
-        await tx.wait()
+        await waitForTransaction(tx)
       }
 
       queryClient.setQueryData(
@@ -103,6 +117,7 @@ const UserAllowance = ({ initial }) => {
         ethers.utils.parseEther(zoomAllowance.toString())
       )
     } catch (e) {
+      debugger
       console.error(e)
     } finally {
       setIsSettingAllowance(false)
@@ -110,11 +125,14 @@ const UserAllowance = ({ initial }) => {
   }
 
   return (
-    <UserAllowanceWrapper className={"helloworld"}>
+    <UserAllowanceWrapper className={'helloworld'}>
       {isLoading ? (
         <CircularProgress></CircularProgress>
       ) : (
-        <h2>Your current zoom allowance: {ethers.utils.formatEther(currentAllowance)} ZOOM</h2>
+        <h2>
+          Your current zoom allowance:{' '}
+          {ethers.utils.formatEther(currentAllowance)} ZOOM
+        </h2>
       )}
       <Grid className="slider-wrapper" container>
         <Grid className="slider" item xs={12} md={8}>
@@ -133,9 +151,15 @@ const UserAllowance = ({ initial }) => {
             fullWidth
             onChange={handleInputChange}
             onBlur={handleBlur}
-            error={compareAsBigNumbers(parseInt(zoomBalance),zoomAllowance) === -1}
-            helperText={compareAsBigNumbers(parseInt(zoomBalance), zoomAllowance) === -1 ? 'Exceeds your ZOOM balance' : null}
-            variant={"standard"}
+            error={
+              compareAsBigNumbers(parseInt(zoomBalance), zoomAllowance) === -1
+            }
+            helperText={
+              compareAsBigNumbers(parseInt(zoomBalance), zoomAllowance) === -1
+                ? 'Exceeds your ZOOM balance'
+                : null
+            }
+            variant={'standard'}
             inputProps={{
               step: 500,
               min: 0,
@@ -166,4 +190,4 @@ const UserAllowance = ({ initial }) => {
   )
 }
 
-export default UserAllowance;
+export default UserAllowance

--- a/src/hooks/useBlockchain.js
+++ b/src/hooks/useBlockchain.js
@@ -58,7 +58,6 @@ const useBlockchain = () => {
     }
 
     const handleConnect = (connectInfo) => {
-      console.log({ connectInfo })
       dispatch(Actions.dAppStateChanged(DAPP_STATES.CONNECTED))
     }
 
@@ -67,7 +66,7 @@ const useBlockchain = () => {
         mustBeMetaMask: true,
       })
 
-      const provider = new ethers.providers.Web3Provider(metamaskProvider)      
+      const provider = new ethers.providers.Web3Provider(metamaskProvider)
       const signer = provider.getSigner()
       const [address, balance] = await Promise.all([
         signer.getAddress(),
@@ -247,8 +246,10 @@ const useBlockchain = () => {
           })
         })
 
-        const { ZoomContract, WMOVRContract } =
-          await loadContracts(signer, network.chainId)
+        const { ZoomContract, WMOVRContract } = await loadContracts(
+          signer,
+          network.chainId
+        )
 
         const zoomBalance = await getWalletZoomBalance(ZoomContract, address)
         const WMOVRBalance = await getWalletWMOVRBalance(WMOVRContract, address)

--- a/src/pages/ViewListing.jsx
+++ b/src/pages/ViewListing.jsx
@@ -31,8 +31,9 @@ import { useQueryClient } from 'react-query'
 import { v4 as uuidv4 } from 'uuid'
 import { useFetchSingleListingQuery } from 'hooks/useListing'
 import { formatAddress } from 'utils/wallet'
-import { styled } from '@mui/material';
+import { styled } from '@mui/material'
 import { compareAsBigNumbers, toBigNumber } from '../utils/BigNumbers'
+import { waitForTransaction } from 'utils/transactions'
 
 const Container = styled('div')(({ theme }) => ({
   backgroundColor: 'white',
@@ -68,7 +69,7 @@ const Container = styled('div')(({ theme }) => ({
       flexWrap: 'wrap',
       [theme.breakpoints.down('md')]: {
         alignItems: 'center',
-        justifyContent: 'center'
+        justifyContent: 'center',
       },
     },
   },
@@ -97,7 +98,6 @@ const HeaderRow = styled(FlexRow)(({ theme }) => ({
   },
 }))
 
-
 const ModalContent = styled('div')({
   position: 'absolute',
   display: 'flex',
@@ -115,7 +115,6 @@ const ModalContent = styled('div')({
     margin: '5px 0',
   },
 })
-
 
 const StyledLogo = styled('img')({
   width: '30px',
@@ -143,9 +142,9 @@ const ListingNFTWrapper = styled('div')({
     },
 
     '& img': {
-    width: '50px',
-    }
-  }
+      width: '50px',
+    },
+  },
 })
 
 const ListingMetadataWrapper = styled('div')(({ theme }) => ({
@@ -165,7 +164,7 @@ const ListingMetadataWrapper = styled('div')(({ theme }) => ({
 
     '& .auction-end h2': {
       textAlign: 'center',
-    }
+    },
   },
 
   '& .seller-date-wrapper': {
@@ -178,17 +177,17 @@ const ListingMetadataWrapper = styled('div')(({ theme }) => ({
 
     '& h1': {
       color: 'black',
-    }
+    },
   },
 
   '& .auction-end': {
     marginTop: '12px',
 
     '& h2': {
-        color: 'gray',
-        fontWeight: 'normal',
-        margin: '0',
-      },
+      color: 'gray',
+      fontWeight: 'normal',
+      margin: '0',
+    },
   },
 
   '& .price-wrapper': {
@@ -207,7 +206,7 @@ const ListingMetadataWrapper = styled('div')(({ theme }) => ({
 
     '& .current-price': {
       color: '#357439',
-    }
+    },
   },
 
   '& .offer-wrapper': {
@@ -219,9 +218,9 @@ const ListingMetadataWrapper = styled('div')(({ theme }) => ({
     marginRight: '24px',
 
     '& a': {
-      marginLeft: '8px !important'
-    }
-  }
+      marginLeft: '8px !important',
+    },
+  },
 }))
 
 const ItemHistoryWrapper = styled('div')(({ theme }) => ({
@@ -249,13 +248,12 @@ const ItemHistoryWrapper = styled('div')(({ theme }) => ({
   '& .bid-table-header th': {
     fontWeight: 'bold',
     fontSize: '1.1rem',
-  }
+  },
 }))
-
 
 const handleSettle = async (history, marketContract, auctionId) => {
   const tx = await marketContract.settle(parseInt(auctionId))
-  await tx.wait()
+  waitForTransaction(tx)
   history.push('/')
 }
 
@@ -308,7 +306,7 @@ const ListingMetadata = ({
   isBidInProgress,
   handleConfirmBid,
   isAuctionOver,
-  walletAddress
+  walletAddress,
 }) => {
   const shortWallet = formatAddress(listing.seller)
   const dateListed = moment(listing.auctionStart * 1000).format(
@@ -320,29 +318,34 @@ const ListingMetadata = ({
   const timezone = momentTimezone.tz(momentTimezone.tz.guess()).zoneAbbr()
   const highestBid =
     compareAsBigNumbers(listing.highestBid, listing.minPrice) === 1
-      ? toBigNumber(listing.highestBid) : toBigNumber(listing.minPrice)
+      ? toBigNumber(listing.highestBid)
+      : toBigNumber(listing.minPrice)
 
-/*
+  /*
   const minOfferAmount =
     Math.max(parseFloat(listing.highestBid), parseFloat(listing.minPrice)) +
     minIncrement
 */
-  let minOfferAmount =
-      ethers.utils.parseEther(listing.highestBid.toString()).gt(ethers.utils.parseEther(listing.minPrice.toString()))
-      ? ethers.utils.parseEther(listing.highestBid.toString())
-      : ethers.utils.parseEther(listing.minPrice.toString());
+  let minOfferAmount = ethers.utils
+    .parseEther(listing.highestBid.toString())
+    .gt(ethers.utils.parseEther(listing.minPrice.toString()))
+    ? ethers.utils.parseEther(listing.highestBid.toString())
+    : ethers.utils.parseEther(listing.minPrice.toString())
 
-      console.log("minOfferAmount before", minOfferAmount, minOfferAmount.toString(), minIncrement);
-      minOfferAmount = minOfferAmount.add(minIncrement);
-      console.log("minOfferAmount after", minOfferAmount.toString());
-
+  minOfferAmount = minOfferAmount.add(minIncrement)
 
   const maxOfferAmount =
-    listing.currency === 'ZOOM' ? ethers.utils.parseEther(zoomBalance) : ethers.utils.parseEther(wmovrBalance)
+    listing.currency === 'ZOOM'
+      ? ethers.utils.parseEther(zoomBalance)
+      : ethers.utils.parseEther(wmovrBalance)
   const canBid =
     listing.currency === 'ZOOM'
-      ? ethers.utils.parseEther(zoomBalance ? zoomBalance : "0").gt(minOfferAmount)
-      : ethers.utils.parseEther(wmovrBalance ? wmovrBalance : "0").gt(minOfferAmount)
+      ? ethers.utils
+          .parseEther(zoomBalance ? zoomBalance : '0')
+          .gt(minOfferAmount)
+      : ethers.utils
+          .parseEther(wmovrBalance ? wmovrBalance : '0')
+          .gt(minOfferAmount)
 
   return (
     <ListingMetadataWrapper>
@@ -373,7 +376,8 @@ const ListingMetadata = ({
           )}
         </p>
         <p className="current-price">
-          Current Price: {ethers.utils.formatEther(highestBid)} {listing.currency}
+          Current Price: {ethers.utils.formatEther(highestBid)}{' '}
+          {listing.currency}
         </p>
       </div>
       <div className="offer-wrapper">
@@ -382,7 +386,12 @@ const ListingMetadata = ({
           currency={listing.currency}
           maxAmount={maxOfferAmount}
           onConfirm={handleConfirmBid}
-          disabled={isBidInProgress || !canBid || isAuctionOver || listing.seller === walletAddress}
+          disabled={
+            isBidInProgress ||
+            !canBid ||
+            isAuctionOver ||
+            listing.seller === walletAddress
+          }
         />
       </div>
     </ListingMetadataWrapper>
@@ -452,7 +461,6 @@ const ViewListing = () => {
   const [approvalModalOpen, setApprovalModalOpen] = useState(false)
   const [bidInProgress, setBidInProgress] = useState(false)
 
-
   const auctionId = parseInt(id)
 
   const {
@@ -468,7 +476,10 @@ const ViewListing = () => {
       const bid = data
       const currentListing = queryClient.getQueryData([
         QUERY_KEYS.listing,
-        { itemNumber: auctionId, marketContractAddress: MarketContract?.address },
+        {
+          itemNumber: auctionId,
+          marketContractAddress: MarketContract?.address,
+        },
       ])
       const randomId = uuidv4()
       const bidWithId = {
@@ -480,21 +491,33 @@ const ViewListing = () => {
         if (currentListing && currentListing.bids) {
           if (currentListing.bids.length > 0) {
             queryClient.setQueryData(
-              [QUERY_KEYS.listing,  { itemNumber: auctionId, marketContractAddress: MarketContract?.address }],
+              [
+                QUERY_KEYS.listing,
+                {
+                  itemNumber: auctionId,
+                  marketContractAddress: MarketContract?.address,
+                },
+              ],
               {
                 ...currentListing,
                 bids: [...currentListing.bids, bidWithId],
-                highestBid: bid.bidAmount
+                highestBid: bid.bidAmount,
               }
             )
           }
         } else {
           queryClient.setQueryData(
-            [QUERY_KEYS.listing,  { itemNumber: auctionId, marketContractAddress: MarketContract?.address }],
+            [
+              QUERY_KEYS.listing,
+              {
+                itemNumber: auctionId,
+                marketContractAddress: MarketContract?.address,
+              },
+            ],
             {
               ...currentListing,
               bids: [bidWithId],
-              highestBid: bid.bidAmount
+              highestBid: bid.bidAmount,
             }
           )
         }
@@ -533,12 +556,21 @@ const ViewListing = () => {
       const { currency, id } = auctionItem
       let currencyContract
 
-      const minAmount = ethers.utils.parseEther(auctionItem?.highestBid.toString()).add(minIncrement)
-        .gt(ethers.utils.parseEther(auctionItem?.minPrice.toString()).add(minIncrement)) ?
-        ethers.utils.parseEther(auctionItem?.highestBid.toString()).add(minIncrement) :
-        ethers.utils.parseEther(auctionItem?.minPrice.toString()).add(minIncrement)
-      
-      console.log("Pre:", amount);
+      const minAmount = ethers.utils
+        .parseEther(auctionItem?.highestBid.toString())
+        .add(minIncrement)
+        .gt(
+          ethers.utils
+            .parseEther(auctionItem?.minPrice.toString())
+            .add(minIncrement)
+        )
+        ? ethers.utils
+            .parseEther(auctionItem?.highestBid.toString())
+            .add(minIncrement)
+        : ethers.utils
+            .parseEther(auctionItem?.minPrice.toString())
+            .add(minIncrement)
+
       if (ethers.utils.parseEther(amount.toString()).lt(minAmount)) {
         throw new Error(`Invalid amount valid : ${amount}`)
       }
@@ -561,10 +593,13 @@ const ViewListing = () => {
 
       setBidInProgress(true)
       setApprovalModalOpen(true)
-      await approveTx.wait()
+      waitForTransaction(approveTx)
       setApprovalModalOpen(false)
-      const bidTx = await contracts.MarketContract.bid(parseInt(id), toBigNumber(amount))
-      await bidTx.wait()
+      const bidTx = await contracts.MarketContract.bid(
+        parseInt(id),
+        toBigNumber(amount)
+      )
+      waitForTransaction(bidTx)
       setBidInProgress(false)
     }
 

--- a/src/pages/ViewListing.jsx
+++ b/src/pages/ViewListing.jsx
@@ -253,7 +253,7 @@ const ItemHistoryWrapper = styled('div')(({ theme }) => ({
 
 const handleSettle = async (history, marketContract, auctionId) => {
   const tx = await marketContract.settle(parseInt(auctionId))
-  waitForTransaction(tx)
+  await waitForTransaction(tx)
   history.push('/')
 }
 
@@ -593,13 +593,13 @@ const ViewListing = () => {
 
       setBidInProgress(true)
       setApprovalModalOpen(true)
-      waitForTransaction(approveTx)
+      await waitForTransaction(approveTx)
       setApprovalModalOpen(false)
       const bidTx = await contracts.MarketContract.bid(
         parseInt(id),
         toBigNumber(amount)
       )
-      waitForTransaction(bidTx)
+      await waitForTransaction(bidTx)
       setBidInProgress(false)
     }
 

--- a/src/scraping/getBidEvents.js
+++ b/src/scraping/getBidEvents.js
@@ -15,13 +15,13 @@ const contract = new ethers.Contract(testBSC, contractJSON.abi, rpcProvider);
 const blocksPerRequest = 5000;
 
 async function watchEvents(eventsCol) {
-  const interface = new ethers.utils.Interface(contractJSON.abi);
+  const etherInterface = new ethers.utils.Interface(contractJSON.abi);
   const filter = {
     address: testBSC,
     topics: [ethers.utils.id('Bid(uint256,uint256,address,uint256[])')],
   };
   contract.provider.on(filter, async (log) => {
-    const { args } = interface.parseLog(log);
+    const { args } = etherInterface.parseLog(log);
     try {
       await eventsCol.insertOne({
         itemNumber: args[0].toNumber(),
@@ -30,7 +30,7 @@ async function watchEvents(eventsCol) {
         timestamp: Date.now() / 1000,
       });
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   });
 }
@@ -67,7 +67,6 @@ async function getLogs(firstBlock, eventsCol) {
       blockToScrape += blocksPerRequest;
     }
 
-    console.log({ allEvents });
     await eventsCol.insertMany(allEvents);
   } catch (err) {
     console.error('ERROR:', err);

--- a/src/utils/listingUtil.js
+++ b/src/utils/listingUtil.js
@@ -1,7 +1,6 @@
 import moment from 'moment';
 
 export const getStatus = (endTime, highestBidder, address) => {
-  // console.log({ highestBidder });
   const now = moment().unix();
   const end = moment(endTime).unix();
 

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -1,0 +1,13 @@
+export const waitForTransaction = async (tx) => {
+    try {
+        await tx.wait();
+    } catch (e) {
+        /**
+         * If the error code is transaction replaced, it's likely that the user just sped it up.
+         * In that case we don't want to throw so the next calls can proceed.
+         */
+        if (e.code !== "TRANSACTION_REPLACED") {
+            throw e;
+        }
+    }
+}

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -53,7 +53,7 @@ export const addAssetToMetamask = async (tokenSymbol, address) => {
       });
     }
   } catch (error) {
-    console.log('addCZXPtoMetaMask error:', error);
+    console.error('addCZXPtoMetaMask error:', error);
   }
 };
 


### PR DESCRIPTION
When user speeds up the transaction, we don't throw an error so subsequent calls can proceed. Plus some formatting and clean up console log.

All contract calls should still work as expected.