### PR TITLE
Mchi/bid allowance

### DIFF
--- a/src/components/AuctionItem.jsx
+++ b/src/components/AuctionItem.jsx
@@ -10,7 +10,6 @@ import zoomCoin from '../assets/zoombies_coin.svg'
 import { Button, CircularProgress, Modal, styled, Grid } from '@mui/material'
 import {
   cardImageBaseURL,
-  marketContractAddress,
   wmovrContractAddress,
   zoomContractAddress,
 } from '../constants'
@@ -239,7 +238,7 @@ const AuctionItem = ({ content, archived }) => {
   const theme = useTheme()
 
   const auctionItem = content
-  const { itemNumber, highestBid } = auctionItem
+  const { itemNumber } = auctionItem
   const coinType =
     auctionItem.saleToken === zoomContractAddress
       ? 'ZOOM'

--- a/src/pages/ViewListing.jsx
+++ b/src/pages/ViewListing.jsx
@@ -13,7 +13,6 @@ import { CircularProgress, Modal, Paper } from '@mui/material'
 import OfferDialog from 'components/OfferDialog'
 import {
   EVENT_TYPES,
-  marketContractAddress,
   QUERY_KEYS,
   ZoombiesStableEndpoint,
   ZoombiesTestingEndpoint,
@@ -32,7 +31,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { useFetchSingleListingQuery } from 'hooks/useListing'
 import { formatAddress } from 'utils/wallet'
 import { styled } from '@mui/material'
-import { compareAsBigNumbers, toBigNumber } from '../utils/BigNumbers'
+import { toBigNumber } from '../utils/BigNumbers'
 import { waitForTransaction } from 'utils/transactions'
 import { useGetZoomAllowanceQuery } from 'hooks/useProfile'
 
@@ -604,27 +603,6 @@ const ViewListing = () => {
         throw new Error(`Invalid amount valid : ${amount}`)
       }
 
-      // switch (currency) {
-      //   case 'ZOOM':
-      //     currencyContract = contracts.ZoomContract
-      //     break
-      //   case 'WMOVR':
-      //     currencyContract = contracts.WMOVRContract
-      //     break
-      //   default:
-      //     throw new Error(`Unhandled currency type: ${currency}`)
-      // }
-
-      // if (currency === "ZOOM") {
-      //   const approveTx = await currencyContract.approve(
-      //     marketContractAddress,
-      //     toBigNumber(amount)
-      //   )
-      //   setApprovalModalOpen(true)
-      //   await approveTx.wait()
-      //   setApprovalModalOpen(false)
-      // }
-
       setBidInProgress(true)
       const bidTx = await contracts.MarketContract.bid(
         parseInt(id),
@@ -632,14 +610,6 @@ const ViewListing = () => {
         { value: currency === 'WMOVR' ? toBigNumber(amount) : 0 }
       )
       await waitForTransaction(bidTx)
-
-      // const bidTx = await contracts.MarketContract.bid(
-      //   parseInt(itemNumber),
-      //   weiAmount,
-      //   {value:movrValue}
-      // );
-      // await bidTx.wait();
-      //
       setBidInProgress(false)
     }
 


### PR DESCRIPTION
Only the last commit is important. The rest are from https://github.com/ryanprice/nft-market/pull/99.

When bid with Zoom, check if user allowance is enough to spend that amount of zoom, else disable the button. Else, the user needs to approve zoom spending before Bid, and it will override with the allowance user set. 

For WMOVR, still approve so bid doesn't throw an error. I can rebase from Derick's PR if his gets merged first.